### PR TITLE
feat: add bakery access middleware for user authorization

### DIFF
--- a/src/modules/bakery/bakery.routes.ts
+++ b/src/modules/bakery/bakery.routes.ts
@@ -5,11 +5,17 @@ import { validateParams } from "@/shared/middlewares/validateParams";
 import { idParamSchema } from "@/shared/schemas/params";
 import { validateSchema } from "@/shared/middlewares/validateSchema";
 import { bakerySchema, updateBakerySchema } from "./bakery.schema";
+import { checkBakeryAccess } from "@/shared/middlewares/checkBakeryAccess";
 
 export const bakeryRouter = Router()
 
+bakeryRouter.use('/:id', checkBakeryAccess)
+
+// "Public" routes (Requires access but not specific bakery ID)
 bakeryRouter.get('/', asyncHandler(BakeryController.getBakeries))
-bakeryRouter.get('/:id', validateParams(idParamSchema), asyncHandler(BakeryController.getBakeryById))
 bakeryRouter.post('/', validateSchema(bakerySchema), asyncHandler(BakeryController.createBakery))
+
+// Routes below require bakery ID
+bakeryRouter.get('/:id', validateParams(idParamSchema), asyncHandler(BakeryController.getBakeryById))
 bakeryRouter.patch('/:id', validateParams(idParamSchema), validateSchema(updateBakerySchema), asyncHandler(BakeryController.updateBakery))
 bakeryRouter.delete('/:id', validateParams(idParamSchema), asyncHandler(BakeryController.deleteBakery))

--- a/src/modules/category/category.routes.ts
+++ b/src/modules/category/category.routes.ts
@@ -5,8 +5,11 @@ import { validateParams } from "@/shared/middlewares/validateParams";
 import { idParamSchema } from "@/shared/schemas/params";
 import { validateSchema } from "@/shared/middlewares/validateSchema";
 import { categorySchema, updateCategorySchema } from "./category.schema";
+import { checkBakeryAccess } from "@/shared/middlewares/checkBakeryAccess";
 
 export const categoryRouter = Router()
+
+categoryRouter.use(checkBakeryAccess)
 
 categoryRouter.get('/', asyncHandler(CategoryController.getCategories))
 categoryRouter.get('/:id', validateParams(idParamSchema), asyncHandler(CategoryController.getCategoryById))

--- a/src/modules/ingredients/ingredient.routes.ts
+++ b/src/modules/ingredients/ingredient.routes.ts
@@ -5,8 +5,11 @@ import { ingredientSchema, updateIngredientSchema } from "@/modules/ingredients/
 import { idParamSchema } from "@/shared/schemas/params";
 import { Router } from "express";
 import { asyncHandler } from "@/shared/utils/async-handler";
+import { checkBakeryAccess } from "@/shared/middlewares/checkBakeryAccess";
 
 export const ingredientRouter = Router();
+
+ingredientRouter.use(checkBakeryAccess);
 
 ingredientRouter.get('/', asyncHandler(IngredientController.getAllIngredients))
 ingredientRouter.get('/:id', validateParams(idParamSchema), asyncHandler(IngredientController.getIngredientByID))

--- a/src/modules/suppliers/supplier.routes.ts
+++ b/src/modules/suppliers/supplier.routes.ts
@@ -5,8 +5,11 @@ import { idParamSchema } from "@/shared/schemas/params";
 import { validateSchema } from "@/shared/middlewares/validateSchema";
 import { supplierSchema, updateSupplierSchema } from "./supplier.schema";
 import { asyncHandler } from "@/shared/utils/async-handler";
+import { checkBakeryAccess } from "@/shared/middlewares/checkBakeryAccess";
 
 export const supplierRouter = Router()
+
+supplierRouter.use(checkBakeryAccess)
 
 supplierRouter.get('/', asyncHandler(SupplierController.getSuppliers))
 supplierRouter.get('/:id', validateParams(idParamSchema), asyncHandler(SupplierController.getSupplierById))

--- a/src/shared/middlewares/checkBakeryAccess.ts
+++ b/src/shared/middlewares/checkBakeryAccess.ts
@@ -1,0 +1,19 @@
+import { NextFunction, Request, Response } from "express";
+import { getUserBakeryId } from "../utils/getUserBakeryId";
+
+export const checkBakeryAccess = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const { userId } = req.user;
+        const userBakeryId = await getUserBakeryId(userId)
+
+        if(!userBakeryId) {
+            return res.status(403).json({ error: "No bakery access found for this user" });
+        }
+
+        req.user.bakeryId = userBakeryId;
+
+        next();
+    } catch (error) {
+        res.status(500).json({ error: "Error checking bakery access" });
+    }
+}


### PR DESCRIPTION
- Create checkBakeryAccess middleware to verify user's bakery access
- Apply middleware to category, ingredient, and supplier routes
- Add selective middleware to bakery routes (ID-specific endpoints only)
- Middleware attaches bakeryId to req.user for downstream use